### PR TITLE
fix: add empty folder to third_party

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,3 +1,9 @@
+grpc (1.51.1-4deepin1) unstable; urgency=medium
+
+  * add empty folder to third_party
+
+ -- bluesky <chenchongbiao@deepin.org>  Wed, 26 Jul 2023 14:35:56 +0800
+
 grpc (1.51.1-3) unstable; urgency=medium
 
   * Link Python gRPC module with all needed Abseil libraries

--- a/debian/rules
+++ b/debian/rules
@@ -74,6 +74,10 @@ override_dh_auto_configure:
 	ln -s /usr/src/googletest/googletest/ \
 		$(CURDIR)/third_party/googletest/
 
+	mkdir -p $(CURDIR)/third_party/envoy-api
+	mkdir -p $(CURDIR)/third_party/googleapis
+	mkdir -p $(CURDIR)/third_party/xds
+
 	dh_auto_configure -O--buildsystem=cmake \
 		-O--builddir=$(BUILD_STATIC_DIR) -- \
 		-DBUILD_SHARED_LIBS=OFF \


### PR DESCRIPTION
Add the action to create an empty folder in the Makefile.

Issue: https://github.com/deepin-community/grpc/issues/2